### PR TITLE
glib and gstreamer are needed for the plugin to be visible in page.rende...

### DIFF
--- a/src/qt/preconfig.sh
+++ b/src/qt/preconfig.sh
@@ -55,8 +55,8 @@ QT_CFG+=' -graphicssystem raster'
 
 # Unix
 QT_CFG+=' -no-dbus'             # Disable D-Bus feature
-QT_CFG+=' -no-glib'             # No need for Glib integration
-QT_CFG+=' -no-gstreamer'        # Turn off GStreamer support
+#QT_CFG+=' -no-glib'             # No need for Glib integration
+#QT_CFG+=' -no-gstreamer'        # Turn off GStreamer support
 QT_CFG+=' -no-gtkstyle'         # Disable theming integration with Gtk+
 QT_CFG+=' -no-cups'             # Disable CUPs support
 QT_CFG+=' -no-sm'


### PR DESCRIPTION
glib and gstreamer are needed for the plugin to be visible in page.render
